### PR TITLE
changes needed for ERS and SMS tests

### DIFF
--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -86,6 +86,7 @@
 <!-- use initial 2015-01-01 ERA5 HICCUP (zhang73) -->
 <!--<ncdata dyn="se" hgrid="ne0np4_CAx32v1"  nlev="128"                     >atm/cam/inic/homme/ifs_oper_T1279_2016080100_mod_subset_CA_ne32_x32_v1_pg2_L128.nc</ncdata>-->
 <ncdata dyn="se" hgrid="ne0np4_CAx32v1"  nlev="128"                     >atm/cam/inic/homme/HICCUP.atm_era5.2015-01-01.ne0np4_CAx32v1_highorder.L128.nc</ncdata>
+<ncdata dyn="se" hgrid="ne0np4_CAx32v1"  nlev="72"                     >atm/cam/inic/homme/HICCUP.atm_era5.2015-01-01.ne0np4_CAx32v1_highorder.L72.EAMv2aer.nc</ncdata>
 
 
 <!-- Worked, and used to generate the inic below for northamerica:  ncdata dyn="se" hgrid="ne0np4_northamericax4v1" nlev="72"    >/global/cscratch1/sd/wlin/northamericax4v1/ifs_oper_T1279_2016080100_mod_subset_to_e3sm_northamericax4v1_topoadj_L72.nc</ncdata-->

--- a/components/eam/bld/namelist_files/use_cases/20TR_eam_chemUCI-Linoz-fire.xml
+++ b/components/eam/bld/namelist_files/use_cases/20TR_eam_chemUCI-Linoz-fire.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0"?>
+<namelist_defaults>
+
+<!-- Set default output options for CMIP6 simulations -->
+<cosp_lite>.true.</cosp_lite>
+
+<!-- For comprehensive history -->
+<history_amwg>.true.</history_amwg>
+<history_aerosol>.true.</history_aerosol>
+<history_aero_optics>.true.</history_aero_optics>
+
+<!-- extra output spec -->
+<history_gaschmbudget_2D> .true.</history_gaschmbudget_2D>
+<tropopause_output_all>.true.</tropopause_output_all>
+<tropopause_E90_thrd>76.0e-9</tropopause_E90_thrd>
+
+<!-- Solar constant from CMIP6 input4MIPS -->
+<solar_data_file>atm/cam/solar/Solar_1850-2299_input4MIPS_c20181106.nc</solar_data_file>
+<solar_data_type>SERIAL</solar_data_type>
+
+<!-- GHG values from CMIP6 input4MIPS -->
+<bndtvghg>atm/cam/ggas/GHG_CMIP-1-2-0_Annual_Global_0000-2014_c20180105.nc</bndtvghg>
+<scenario_ghg>RAMPED</scenario_ghg>
+
+<!-- Stratospheric aerosols from CMIP6 input4MIPS -->
+<prescribed_volcaero_datapath>atm/cam/volc                                             </prescribed_volcaero_datapath>
+<prescribed_volcaero_file>CMIP_DOE-ACME_radiation_1850-2014_v3_c20171205.nc</prescribed_volcaero_file>
+<prescribed_volcaero_filetype>VOLC_CMIP6					       </prescribed_volcaero_filetype>
+<prescribed_volcaero_type>SERIAL</prescribed_volcaero_type>
+
+<!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
+<ext_frc_type>INTERP_MISSING_MONTHS</ext_frc_type>
+<no2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_NO2_aircraft_vertical_1750-2015_1.9x2.5_c20170608.nc </no2_ext_file>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_elev_1850-2014_c180205.nc </so2_ext_file>
+<soag_ext_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_soag_elev_1850-2014_c180205.nc </soag_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_elev_1850-2014_c180205.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_elev_1850-2014_c180205.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_elev_1850-2014_c180205.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_elev_1850-2014_c180205.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_elev_1850-2014_c180205.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_elev_1850-2014_c180205.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_elev_1850-2014_c180205.nc </so4_a2_ext_file>
+
+<!-- Surface emissions for MAM4.  CMIP6 input4mips data -->
+<srf_emis_type>INTERP_MISSING_MONTHS</srf_emis_type>
+<c2h4_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C2H4_surface_1850-2014_1.9x2.5_c20210323.nc </c2h4_emis_file>
+<c2h6_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C2H6_surface_1850-2014_1.9x2.5_c20210323.nc </c2h6_emis_file>
+<c3h8_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_C3H8_surface_1850-2014_1.9x2.5_c20210323.nc </c3h8_emis_file>
+<ch2o_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH2O_surface_1850-2014_1.9x2.5_c20210323.nc </ch2o_emis_file>
+<ch3cho_emis_file     >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH3CHO_surface_1850-2014_1.9x2.5_c20210323.nc </ch3cho_emis_file>
+<ch3coch3_emis_file   >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CH3COCH3_surface_1850-2014_1.9x2.5_c20210323.nc </ch3coch3_emis_file>
+<co_emis_file         >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_CO_surface_1850-2014_1.9x2.5_c20210323.nc </co_emis_file>
+<isop_emis_file       >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_ISOP_surface_1850-2014_1.9x2.5_c20210323.nc </isop_emis_file>
+<nox_emis_file         >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions-cmip6_e3sm_NO_surface_1850-2014_1.9x2.5_c20220425.nc </nox_emis_file>
+<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1850-2100.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20160727.nc</dms_emis_file>
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so2_surf_1850-2014_c180205.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_bc_a4_surf_1850-2014_c180205.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a1_surf_1850-2014_c180205.nc </mam7_num_a1_emis_file> 
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a2_surf_1850-2014_c180205.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_num_a4_surf_1850-2014_c180205.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_pom_a4_surf_1850-2014_c180205.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a1_surf_1850-2014_c180205.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/DECK_ne30/cmip6_mam4_so4_a2_surf_1850-2014_c180205.nc </so4_a2_emis_file>
+<e90_emis_file        >atm/cam/chem/trop_mozart_aero/emis/chem_gases/2degrees/emissions_E90_surface_1750-2015_1.9x2.5_c20210408.nc </e90_emis_file>
+
+<airpl_emis_file></airpl_emis_file>   <!-- need to be empty, but if specifying empty here, the value would be root of input_data_path -->
+
+<!-- Prescribed oxidants for aerosol chemistry.   Ozone is from CMIP6 input4MIPS file -->
+<tracer_cnst_type    >CYCLICAL</tracer_cnst_type>
+<tracer_cnst_cycle_yr>1995</tracer_cnst_cycle_yr>
+<tracer_cnst_file    >ch4_oxid_1.9x2.5_L26_1990-1999clim.c090804.nc</tracer_cnst_file>
+<tracer_cnst_filelist>''</tracer_cnst_filelist>
+<tracer_cnst_datapath>atm/cam/chem/methane</tracer_cnst_datapath>
+<tracer_cnst_specifier>'CH4'</tracer_cnst_specifier>
+
+<!-- prescribed methane  -->
+<prescribed_ghg_file      >ch4_oxid_1.9x2.5_L26_1990-1999clim.c090804.nc</prescribed_ghg_file>
+<prescribed_ghg_datapath  >atm/cam/chem/methane</prescribed_ghg_datapath>
+<prescribed_ghg_type      >CYCLICAL</prescribed_ghg_type>
+<prescribed_ghg_cycle_yr  >1995</prescribed_ghg_cycle_yr>
+<prescribed_ghg_filelist  >''</prescribed_ghg_filelist>
+<prescribed_ghg_specifier>'prsd_ch4:CH4'</prescribed_ghg_specifier>
+
+<!-- read surface fluxes from a dataset on model native grid-->
+<sfx_data_file>''</sfx_data_file>
+<sfx_data_path>''</sfx_data_path>
+<sfx_data_type>'INTERP_MISSING_MONTHS'</sfx_data_type>
+
+
+<!-- rad_climate -->
+<rad_climate>
+  'A:Q:H2O', 'N:O2:O2', 'N:CO2:CO2',
+  'A:O3:O3', 'N:N2O:N2O', 'N:CH4:CH4',
+  'N:CFC11:CFC11', 'N:CFC12:CFC12', 'M:mam4_mode1:$INPUTDATA_ROOT/atm/cam/physprops/mam4_mode1_rrtmg_aeronetdust_c141106.nc',
+  'M:mam4_mode2:$INPUTDATA_ROOT/atm/cam/physprops/mam4_mode2_rrtmg_c130628.nc', 'M:mam4_mode3:$INPUTDATA_ROOT/atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_c141106.nc', 'M:mam4_mode4:$INPUTDATA_ROOT/atm/cam/physprops/mam4_mode4_rrtmg_c130628.nc'
+</rad_climate>
+
+<!-- Marine organic aerosol namelist settings -->
+<mam_mom_mixing_state>3</mam_mom_mixing_state>
+<mam_mom_cycle_yr  >1                                                                                    </mam_mom_cycle_yr  >
+<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                                  </mam_mom_datapath  >
+<mam_mom_datatype  >'CYCLICAL'										 </mam_mom_datatype  >
+<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc'                 </mam_mom_filename  > <!-- Using the 2000 file, for now -->
+<mam_mom_fixed_tod >0											 </mam_mom_fixed_tod >
+<mam_mom_fixed_ymd >0											 </mam_mom_fixed_ymd >
+<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'			 </mam_mom_specifier >
+
+<!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
+<chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_0003-2017_c20171114.nc</chlorine_loading_file>
+<chlorine_loading_type      >SERIAL</chlorine_loading_type>
+<linoz_data_file            >linv3_1849-2015_2010JPL_cmip6_historical_10deg_58km_c20210625.nc</linoz_data_file>
+<linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
+<linoz_data_type            >INTERP_MISSING_MONTHS</linoz_data_type>
+
+<!-- Set surface area density (SAD) variables -->
+<sad_type>SERIAL</sad_type>
+
+<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
+<drydep_method       >'xactive_lnd'</drydep_method>
+<drydep_list         >'O3','H2O2','CH2O','CH3OOH','NO','NO2','HNO3','HO2NO2','PAN','CO','CH3COCH3','C2H5OOH','CH3CHO','H2SO4','SO2','NO3','N2O5'</drydep_list>
+<gas_wetdep_method   >'NEU'</gas_wetdep_method>
+<gas_wetdep_list     >'C2H5OOH','CH2O','CH3CHO','CH3OOH','H2O2','H2SO4','HNO3','HO2NO2','SO2'</gas_wetdep_list>
+<fstrat_efold_list>'CH2O', 'CH3O2', 'CH3OOH', 'PAN', 'CO', 'C2H6', 'C3H8', 'C2H4', 'ROHO2', 'CH3COCH3', 'C2H5O2', 'C2H5OOH', 'CH3CHO', 'CH3CO3', 'ISOP', 'ISOPO2', 'MVKMACR', 'MVKO2'</fstrat_efold_list>
+<fstrat_list         >''</fstrat_list>
+</namelist_defaults>

--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -48,7 +48,8 @@
       <value compset="_EAM%CMIP6"    >-clubb_sgs -microphys mg2 -chem linoz_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_EAM%AR5sf"    >-clubb_sgs -microphys mg2 -chem superfast_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72</value>
       <value compset="_EAM%CHEMUCI-LINOZV2"  >-clubb_sgs -microphys mg2 -chem superfast_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72 -usr_mech_infile $SRCROOT/components/eam/chem_proc/inputs/pp_chemUCI_mam4_resus_mom_soag_tag.in</value>
-      <value compset="_EAM%CHEMUCI-LINOZV3"  >-clubb_sgs -microphys mg2 -chem superfast_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72 -usr_mech_infile $SRCROOT/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam4_resus_mom_soag_tag.in</value>
+      <value compset="_EAM%CHEMUCI-LINOZV3*"  >-clubb_sgs -microphys mg2 -chem superfast_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72 -usr_mech_infile $SRCROOT/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam4_resus_mom_soag_tag.in</value>
+      <value compset="_EAM%FIRE-CHEMUCI-LINOZV3"  >-clubb_sgs -microphys mg2 -chem superfast_mam4_resus_mom_soag -rain_evap_to_coarse_aero -nlev 72 -usr_mech_infile $SRCROOT/components/eam/chem_proc/inputs/pp_chemUCI_linozv3_mam4_resus_mom_soag_tag.in</value>
       <value compset="_EAM%MOZM"     >-chem trop_mozart_mam3 -age_of_air_trcs</value>
       <value compset="_EAM%PM"       >-chem none</value>
       <value compset="_EAM%SMA3"     >-chem trop_strat_mam3 -age_of_air_trcs</value>
@@ -149,7 +150,8 @@
       <value compset="SSP585(?:SOI)?_EAM.*CMIP6.*_BGC%B">SSP585_cam5_CMIP6_bgc</value>
       <value compset="20TR(?:SOI)?_EAM.*AR5sf" >20TR_E3SMv1_superfast_ar5-emis</value>
       <value compset="20TRS_EAM.*AR5sf">20TRS_E3SMv1_superfast_ar5-emis</value>
-      <value compset="20TR(?:SOI)?_EAM.*CHEMUCI.*LINOZ"  >20TR_eam_chemUCI-Linoz</value>
+      <value compset="20TR(?:SOI)?_EAM%CHEMUCI-LINOZ*"  >20TR_eam_chemUCI-Linoz</value>
+      <value compset="20TR(?:SOI)?_EAM%FIRE-CHEMUCI-LINOZ*"  >20TR_eam_chemUCI-Linoz-fire</value>
       <value compset="1850(?:SOI)?_EAM%WCCM"   >waccm_1850_cam5</value>
       <value compset="2000(?:SOI)?_EAM%WCCM"   >waccm_2000_cam5</value>
       <value compset="_EAM%SMA3"       >2000_cam5_trop_strat_mam3</value>

--- a/components/eam/cime_config/config_compsets.xml
+++ b/components/eam/cime_config/config_compsets.xml
@@ -38,6 +38,11 @@
   </compset>
 
   <compset>
+    <alias>F20TR_chemUCI-Linozv3-fire</alias>
+    <lname>20TR_EAM%FIRE-CHEMUCI-LINOZV3_ELM%SPBC_CICE%PRES_DOCN%DOM_MOSART_SGLC_SWAV</lname>
+  </compset>
+
+  <compset>
     <alias>F1950</alias>
     <lname>1950_EAM%CMIP6_ELM%SPBC_CICE%PRES_DOCN%DOM_SROF_SGLC_SWAV</lname>
   </compset>

--- a/components/eam/src/chemistry/mozart/rate_diags.F90
+++ b/components/eam/src/chemistry/mozart/rate_diags.F90
@@ -76,7 +76,7 @@ contains
   subroutine rate_diags_calc( rxt_rates, vmr, m, ncol, lchnk, pver, pdeldry, mbar )
 
     use mo_rxt_rates_conv, only: set_rates
-    use chem_mods,    only : gas_pcnst
+    use chem_mods,    only : gas_pcnst, rxntot
 
     real(r8), intent(inout) :: rxt_rates(:,:,:) ! 'molec/cm3/sec'
     real(r8), intent(in)    :: vmr(:,:,:)
@@ -87,7 +87,7 @@ contains
 
     integer :: i, k
 
-    real(r8)  :: rxt_rates_vmr(ncol,pver,gas_pcnst) ! 'vmr/sec'
+    real(r8)  :: rxt_rates_vmr(ncol,pver,max(1,rxntot)) ! 'vmr/sec'
     real(r8)  :: wrk(ncol,pver)
     real(r8)  :: wrk_sum(ncol)
     real(r8)  :: adv_mass_ch4
@@ -119,7 +119,7 @@ contains
 
     call set_rates( rxt_rates, vmr, ncol )
 
-    rxt_rates_vmr = rxt_rates    
+    rxt_rates_vmr = rxt_rates
 
     do i = 1, rxt_tag_cnt
        ! convert from vmr/sec to molecules/cm3/sec

--- a/components/eam/src/chemistry/utils/tracer_data.F90
+++ b/components/eam/src/chemistry/utils/tracer_data.F90
@@ -286,7 +286,7 @@ contains
     endif
 
    !find_spectrc_ncol = INDEX(filename, 'bc_a4') !(zhang73)
-   if(flds(2)%fldnam.eq.'shf'.and.(.not.file%is_ncol)) file%is_ncol = .true. !set sfx_data%file%is_ncol=.true. (zhang73)
+   if((flds(mxnflds)%fldnam.eq.'shf'.or.flds(mxnflds)%fldnam.eq.'lhf'.or.flds(mxnflds)%fldnam.eq.'lwup').and.(.not.file%is_ncol)) file%is_ncol = .true. !set sfx_data%file%is_ncol=.true. (zhang73)
    if(masterproc.and.file%is_ncol) write(iulog,*) '(zhang73 trcdata_init) file%curr_data_times:',file%curr_data_times
    if (masterproc) then
       flds_loop1: do f = 1,mxnflds

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -299,6 +299,8 @@ lnd/clm2/surfdata_map/surfdata_ne16np4_simyr2000_c160108.nc</fsurdat>
 lnd/clm2/surfdata_map/surfdata_ne11np4_simyr2000_c160614.nc</fsurdat>
 <fsurdat hgrid="ne4np4"      sim_year="2000" use_crop=".false." >
 lnd/clm2/surfdata_map/surfdata_ne4np4_simyr2000_c160614.nc</fsurdat>
+<fsurdat hgrid="ne4np4.pg2" sim_year="1850" >
+lnd/clm2/surfdata_map/surfdata_ne4pg2_simyr1850_c210722.nc</fsurdat>
 <fsurdat hgrid="ne4np4.pg2" sim_year="2000" >
 lnd/clm2/surfdata_map/surfdata_ne4pg2_simyr2000_c190620.nc</fsurdat>
 <fsurdat hgrid="ne4np4.pg2" sim_year="2010" >

--- a/components/elm/bld/namelist_files/use_cases/20thC_transient.xml
+++ b/components/elm/bld/namelist_files/use_cases/20thC_transient.xml
@@ -30,5 +30,6 @@
 <stream_year_last_popdens  phys="elm" use_cn=".true."   >2010</stream_year_last_popdens>
 <model_year_align_popdens  phys="elm" use_cn=".true."   >1850</model_year_align_popdens>
 
+<check_dynpft_consistency>.false.</check_dynpft_consistency>
 
 </namelist_defaults>

--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -558,6 +558,7 @@
       <value compset="_EAM.*_ELM.*MPASO" grid="a%ne4np4">6</value>
       <value compset="_EAM.*_ELM.*MPASO" grid="a%ne11np4">4</value>
       <value compset="_EAM.*_ELM.*MPASO" grid="a%ne120np4">8</value>
+      <value compset="20TR_" grid="a%ne4np4">$ATM_NCPL</value>
     </values>
     <group>run_coupling</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
Passed tests:
ERS_Ld3.ne4pg2_ne4pg2.F20TR_chemUCI-Linozv3-fire.dane_intel
SMS_Ld1.ne4pg2_ne4pg2.F20TR_chemUCI-Linozv3-fire.dane_intel
ERS_D_Ld3.ne4pg2_ne4pg2.F20TR_chemUCI-Linozv3-fire.dane_intel
SMS_D_Ld1.ne4pg2_ne4pg2.F20TR_chemUCI-Linozv3-fire.dane_intel

Added a new compset for these tests because we do not want to add sfx_data settings in the default F20TR_chemUCI-Linozv3 compset. It does not affect the use of the F20TR_chemUCI-Linozv3 compset, but we have to add sfx_data settings manually in the runscripts.